### PR TITLE
Minor improvements (mainly to the UI)

### DIFF
--- a/addons/NormalMap/Normal Map Generator.gd
+++ b/addons/NormalMap/Normal Map Generator.gd
@@ -4,18 +4,19 @@ extends Control
 var texture_rect
 var viewport
 var current_path = "./generated.png"
-var track_mouse = false
+var light2d_node = null
+var viewport_container_node = null
+
 
 func _ready():
-	texture_rect = $VBoxContainer/ViewportContainer/Viewport/TextureRect
-	viewport = $VBoxContainer/ViewportContainer/Viewport
+	texture_rect = $GUI/ViewportContainer/Viewport/TextureRect
+	viewport = $GUI/ViewportContainer/Viewport
 	viewport.size = texture_rect.texture.get_size()
+	
+	light2d_node = $GUI/ViewportContainer/Viewport/TextureRect/Light2D
+	viewport_container_node = $GUI/ViewportContainer
+	$GUI/HBoxContainer_ColorPicker/ColorPickerButton.color = light2d_node.color
 
-func _process(delta):
-	if (track_mouse):
-		if Input.is_action_pressed("click"):
-			print("click")
-			$VBoxContainer/ViewportContainer/Viewport/TextureRect/Light2D.global_position = get_global_mouse_position()
 
 func _on_Normal_toggled(button_pressed):
 	texture_rect.material.set_shader_param("normal_preview",button_pressed)
@@ -57,8 +58,12 @@ func _on_Button_pressed():
 	img.flip_y()
 	print(img.save_png(current_path))
 
+
 func _on_TextureButton_pressed():
-	$FileDialog.popup()
+	# Make the file dialog half the size of the Godot editor and make it popup in the center.
+	$FileDialog.rect_size = get_tree().root.size / 2;
+	$FileDialog.popup_centered();
+
 
 func _on_FileDialog_file_selected(path):
 	var img = Image.new()
@@ -68,9 +73,35 @@ func _on_FileDialog_file_selected(path):
 		texture_rect.texture = itex
 		var aux = path.rsplit(".",true,1)
 		current_path = aux[0]+"_n."+aux[1]
+		
+		# Change viewport size to match the new image size
+		$GUI/ViewportContainer/Viewport.size = img.get_size();
 
-func _on_TextureRect_mouse_entered():
-	track_mouse = true;
 
-func _on_TextureRect_mouse_exited():
-	track_mouse = false;
+# Used for tracking the mouse and other input events.
+# Currently this is only used to move the Light2D node.
+func _input(event):
+	if (event is InputEventMouseButton):
+		
+		var mouse_pos = get_tree().root.get_mouse_position();
+		
+		# Check if the mouse is within the bounds of the Viewport container
+		# NOTE: this is perhaps not the most performance friendly way of checking, may need to be replaced later.
+		if Rect2(viewport_container_node.rect_global_position, viewport_container_node.rect_size).has_point(get_tree().root.get_mouse_position()):
+			if event.pressed == true and event.button_index == BUTTON_LEFT:
+				
+				# First, get the position of the mouse within the rectangle of the ViewportContainer
+				var relative_mouse_pos = mouse_pos - rect_global_position
+				
+				# Get the position relative to the Viewport.
+				# First, convert the position so it is in a 0-1 range on both axis.
+				var light_pos = relative_mouse_pos / viewport_container_node.rect_size
+				# Multiple by the viewport size so the position is within viewport space.
+				light_pos *= $GUI/ViewportContainer/Viewport.size
+				# Finally, set the position.
+				light2d_node.global_position = light_pos
+
+
+# Changes the Light2D node color based on input from the ColorPickerButton
+func _on_ColorPickerButton_color_changed(color):
+	light2d_node.color = color

--- a/addons/NormalMap/Normal Map Generator.tscn
+++ b/addons/NormalMap/Normal Map Generator.tscn
@@ -8,10 +8,10 @@
 [sub_resource type="ShaderMaterial" id=1]
 shader = ExtResource( 2 )
 shader_param/normal_preview = false
-shader_param/emboss_height = 0.05
-shader_param/bump_height = 0.18
-shader_param/blur = 2.0
-shader_param/bump = 19.0
+shader_param/emboss_height = 1.06
+shader_param/bump_height = 0.95
+shader_param/blur = 1.0
+shader_param/bump = 2.0
 shader_param/invertX = true
 shader_param/invertY = true
 shader_param/with_distance = true
@@ -20,25 +20,33 @@ shader_param/with_emboss = true
 [node name="Normal Map Generator" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_right = -624.0
+margin_bottom = 20.0
 script = ExtResource( 1 )
 
 [node name="FileDialog" type="FileDialog" parent="."]
 margin_top = 4.0
 margin_right = 274.0
 margin_bottom = 204.0
-window_title = "Abrir un archivo"
+window_title = "Open a File"
 resizable = true
 mode = 0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="GUI" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
 
-[node name="ViewportContainer" type="ViewportContainer" parent="VBoxContainer"]
-margin_right = 138.0
-margin_bottom = 128.0
+[node name="ViewportContainer" type="ViewportContainer" parent="GUI"]
+margin_left = 50.0
+margin_right = 350.0
+margin_bottom = 300.0
+rect_min_size = Vector2( 300, 300 )
+mouse_default_cursor_shape = 3
 size_flags_horizontal = 15
 size_flags_vertical = 15
+stretch = true
 
-[node name="Viewport" type="Viewport" parent="VBoxContainer/ViewportContainer"]
+[node name="Viewport" type="Viewport" parent="GUI/ViewportContainer"]
 size = Vector2( 128, 128 )
 own_world = true
 transparent_bg = true
@@ -48,14 +56,14 @@ disable_3d = true
 usage = 0
 render_target_update_mode = 3
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/ViewportContainer/Viewport"]
+[node name="TextureRect" type="TextureRect" parent="GUI/ViewportContainer/Viewport"]
 light_mask = 2
 material = SubResource( 1 )
 mouse_default_cursor_shape = 3
 texture = ExtResource( 3 )
 stretch_mode = 6
 
-[node name="Light2D" type="Light2D" parent="VBoxContainer/ViewportContainer/Viewport/TextureRect"]
+[node name="Light2D" type="Light2D" parent="GUI/ViewportContainer/Viewport/TextureRect"]
 position = Vector2( 127.877, 11.4031 )
 texture = ExtResource( 4 )
 color = Color( 1, 0.984314, 0, 1 )
@@ -63,60 +71,98 @@ energy = 2.06
 range_height = 15.0
 range_item_cull_mask = 2
 
-[node name="TextureButton" type="Button" parent="VBoxContainer"]
-margin_top = 132.0
-margin_right = 138.0
-margin_bottom = 152.0
+[node name="HBoxContainer_ColorPicker" type="HBoxContainer" parent="GUI"]
+editor/display_folded = true
+anchor_right = 1.0
+margin_top = 308.0
+margin_bottom = 332.0
+alignment = 1
+
+[node name="Label" type="Label" parent="GUI/HBoxContainer_ColorPicker"]
+margin_left = 75.0
+margin_top = 5.0
+margin_right = 201.0
+margin_bottom = 19.0
+text = "Preview Light Color:"
+
+[node name="ColorPickerButton" type="ColorPickerButton" parent="GUI/HBoxContainer_ColorPicker"]
+margin_left = 205.0
+margin_right = 325.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 120, 0 )
+color = Color( 1, 0.984314, 0, 1 )
+
+[node name="TextureButton" type="Button" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -280.0
+margin_bottom = -260.0
 text = "Texture..."
 
-[node name="Normal" type="CheckBox" parent="VBoxContainer"]
-margin_top = 156.0
-margin_right = 138.0
-margin_bottom = 180.0
+[node name="Normal" type="CheckBox" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -256.0
+margin_bottom = -232.0
 text = "Normal Preview"
 
-[node name="Emboss" type="CheckBox" parent="VBoxContainer"]
-margin_top = 184.0
-margin_right = 138.0
-margin_bottom = 208.0
+[node name="Emboss" type="CheckBox" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -228.0
+margin_bottom = -204.0
 pressed = true
 text = "Emboss:"
 
-[node name="Emboss Height" type="HSlider" parent="VBoxContainer"]
-margin_top = 212.0
-margin_right = 138.0
-margin_bottom = 228.0
+[node name="Emboss Height" type="HSlider" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -200.0
+margin_bottom = -184.0
 max_value = 2.0
 step = 0.01
 value = 0.1
+ticks_on_borders = true
 
-[node name="Bump" type="CheckBox" parent="VBoxContainer"]
-margin_top = 232.0
-margin_right = 138.0
-margin_bottom = 256.0
+[node name="Bump" type="CheckBox" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -180.0
+margin_bottom = -156.0
 pressed = true
 text = "Bump:"
 
-[node name="Bump Height" type="HSlider" parent="VBoxContainer"]
-margin_top = 260.0
-margin_right = 138.0
-margin_bottom = 276.0
+[node name="Bump Height" type="HSlider" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -152.0
+margin_bottom = -136.0
 max_value = 2.0
 step = 0.01
 value = 0.1
+ticks_on_borders = true
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 280.0
-margin_right = 138.0
-margin_bottom = 304.0
+[node name="HBoxContainer" type="HBoxContainer" parent="GUI"]
+editor/display_folded = true
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -132.0
+margin_bottom = -108.0
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="GUI/HBoxContainer"]
 margin_top = 5.0
 margin_right = 30.0
 margin_bottom = 19.0
 text = "Blur:"
 
-[node name="SpinBoxBlur" type="SpinBox" parent="VBoxContainer/HBoxContainer"]
+[node name="SpinBoxBlur" type="SpinBox" parent="GUI/HBoxContainer"]
 margin_left = 34.0
 margin_right = 108.0
 margin_bottom = 24.0
@@ -125,18 +171,21 @@ value = 1.0
 rounded = true
 suffix = "px"
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 308.0
-margin_right = 138.0
-margin_bottom = 332.0
+[node name="HBoxContainer2" type="HBoxContainer" parent="GUI"]
+editor/display_folded = true
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -104.0
+margin_bottom = -80.0
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer2"]
+[node name="Label" type="Label" parent="GUI/HBoxContainer2"]
 margin_top = 5.0
 margin_right = 60.0
 margin_bottom = 19.0
 text = "Distance:"
 
-[node name="SpinBoxDistance" type="SpinBox" parent="VBoxContainer/HBoxContainer2"]
+[node name="SpinBoxDistance" type="SpinBox" parent="GUI/HBoxContainer2"]
 margin_left = 64.0
 margin_right = 138.0
 margin_bottom = 24.0
@@ -144,36 +193,42 @@ value = 10.0
 rounded = true
 suffix = "px"
 
-[node name="InvertX" type="CheckBox" parent="VBoxContainer"]
-margin_top = 336.0
-margin_right = 138.0
-margin_bottom = 360.0
+[node name="InvertX" type="CheckBox" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -76.0
+margin_bottom = -52.0
 pressed = true
 text = "Invert X"
 
-[node name="InvertY" type="CheckBox" parent="VBoxContainer"]
-margin_top = 364.0
-margin_right = 138.0
-margin_bottom = 388.0
+[node name="InvertY" type="CheckBox" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -48.0
+margin_bottom = -24.0
 pressed = true
 text = "Invert Y"
 
-[node name="Button" type="Button" parent="VBoxContainer"]
-margin_top = 392.0
-margin_right = 138.0
-margin_bottom = 412.0
+[node name="Button" type="Button" parent="GUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -20.0
 text = "Generate"
 [connection signal="file_selected" from="FileDialog" to="." method="_on_FileDialog_file_selected"]
-[connection signal="mouse_entered" from="VBoxContainer/ViewportContainer/Viewport/TextureRect" to="." method="_on_TextureRect_mouse_entered"]
-[connection signal="mouse_exited" from="VBoxContainer/ViewportContainer/Viewport/TextureRect" to="." method="_on_TextureRect_mouse_exited"]
-[connection signal="pressed" from="VBoxContainer/TextureButton" to="." method="_on_TextureButton_pressed"]
-[connection signal="toggled" from="VBoxContainer/Normal" to="." method="_on_Normal_toggled"]
-[connection signal="toggled" from="VBoxContainer/Emboss" to="." method="_on_Emboss_toggled"]
-[connection signal="value_changed" from="VBoxContainer/Emboss Height" to="." method="_on_Emboss_Height_value_changed"]
-[connection signal="toggled" from="VBoxContainer/Bump" to="." method="_on_Bump_toggled"]
-[connection signal="value_changed" from="VBoxContainer/Bump Height" to="." method="_on_Bump_Height_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/HBoxContainer/SpinBoxBlur" to="." method="_on_SpinBoxBlur_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/HBoxContainer2/SpinBoxDistance" to="." method="_on_SpinBoxDistance_value_changed"]
-[connection signal="toggled" from="VBoxContainer/InvertX" to="." method="_on_InvertX_toggled"]
-[connection signal="toggled" from="VBoxContainer/InvertY" to="." method="_on_InvertY_toggled"]
-[connection signal="pressed" from="VBoxContainer/Button" to="." method="_on_Button_pressed"]
+[connection signal="mouse_entered" from="GUI/ViewportContainer/Viewport/TextureRect" to="." method="_on_TextureRect_mouse_entered"]
+[connection signal="mouse_exited" from="GUI/ViewportContainer/Viewport/TextureRect" to="." method="_on_TextureRect_mouse_exited"]
+[connection signal="color_changed" from="GUI/HBoxContainer_ColorPicker/ColorPickerButton" to="." method="_on_ColorPickerButton_color_changed"]
+[connection signal="pressed" from="GUI/TextureButton" to="." method="_on_TextureButton_pressed"]
+[connection signal="toggled" from="GUI/Normal" to="." method="_on_Normal_toggled"]
+[connection signal="toggled" from="GUI/Emboss" to="." method="_on_Emboss_toggled"]
+[connection signal="value_changed" from="GUI/Emboss Height" to="." method="_on_Emboss_Height_value_changed"]
+[connection signal="toggled" from="GUI/Bump" to="." method="_on_Bump_toggled"]
+[connection signal="value_changed" from="GUI/Bump Height" to="." method="_on_Bump_Height_value_changed"]
+[connection signal="value_changed" from="GUI/HBoxContainer/SpinBoxBlur" to="." method="_on_SpinBoxBlur_value_changed"]
+[connection signal="value_changed" from="GUI/HBoxContainer2/SpinBoxDistance" to="." method="_on_SpinBoxDistance_value_changed"]
+[connection signal="toggled" from="GUI/InvertX" to="." method="_on_InvertX_toggled"]
+[connection signal="toggled" from="GUI/InvertY" to="." method="_on_InvertY_toggled"]
+[connection signal="pressed" from="GUI/Button" to="." method="_on_Button_pressed"]

--- a/project.godot
+++ b/project.godot
@@ -18,10 +18,6 @@ _global_script_class_icons={
 config/name="NormalMap"
 config/icon="res://icon.png"
 
-[editor_plugins]
-
-enabled=PoolStringArray( "NormalMap" )
-
 [input]
 
 click={


### PR DESCRIPTION
Hey Azagaya! Thanks for releasing the project! It looks quite interesting and I will need to take a closer look at how it all works soon, especially the shader for making the normal map.

I noticed the plugin doesn't resize nicely with different windows, so I made some changes to the UI so it scales better with different sized windows. It is not perfect, but it resizes a little bit better, in my opinion. While I was making the UI changes, I kinda got carried away and added some additional functionality.

Changes are as follows:

* Removed the VBoxContainer and replaced it with a normal Control node called `GUI`.
  * This allowed for better control over how the plugin changes with the window size.
* Both the `Normal Map Generate` node and the `GUI` node have their layouts set to `Full Rect` so they will resize to take the entire available plugin window space.
* All the children of the `GUI` node now have anchors set to either to `Top Wide` or `Bottom Wide` so they resize correctly.
  * One exception is the `ViewportContainer` node, as I couldn't get it resizing correctly. It's anchor is set to  `Center Top`
* Added a new `HBoxContainer` for setting the color of the `Light2D` node. Children are a `Label` node and a `ColorPickerButton` node.
  * The `color_changed` signal is connected from the `ColorPickerButton` to a function that sets the color of the `Light2D` Node.
  * Changed `_ready` so that it sets the color of the button to the default `Light2D` node color.
* Added the `_input` function to `Normal Map Generator.gd`.
  * Now when a click is detected within the `ViewportContainer` node, the `Light2D` node will be moved to the cursor position.
  * Changed the cursor icon showed when over the `ViewportContainer` node to a Cross (was an arrow)
  * This *should* work with any sized Viewport/Texture, but I didn't do extensive testing.
* Added a couple new class variables to `Normal Map Generator.gd`
* Other small improvements/changes I forgot... I think that is all of them, but I wasn't writing this done as I went, so there might be a few I missed.

I can separate these additions into different pull requests if you want, to make it easier to manage and so changes can be added/removed.

One minor thing I noticed is that the plugin really slows down when a large texture is loaded. I loaded a 2048x2048 texture into the plugin as a test and it made the editor run really slow. I think it probably has to do with the pixel density of the texture, but I don't know for sure.
This probably isn't a huge problem, I doubt many people are inputting 2048x2048 textures into the plugin, but I thought I'd mention it before I forgot.

Regardless, hopefully these changes are helpful. 🙂